### PR TITLE
Add reusable receive messages

### DIFF
--- a/Desktop/Tempest/BufferValueReader.cs
+++ b/Desktop/Tempest/BufferValueReader.cs
@@ -120,6 +120,19 @@ namespace Tempest
 			return b;
 		}
 
+		public void ReadBytesInto (byte[] target, int offset, int count)
+		{
+			if (target == null)
+				throw new ArgumentNullException (nameof (target));
+			if (offset < 0 || offset >= target.Length)
+				throw new ArgumentOutOfRangeException (nameof (offset), "offset must be in the bounds of the target");
+			if (count < 0 || offset + count > target.Length)
+				throw new ArgumentOutOfRangeException (nameof (count));
+
+			Buff.BlockCopy (this.buffer, Position, target, offset, count);
+			Position += count;
+		}
+
 		public sbyte ReadSByte()
 		{
 			#if !SAFE

--- a/Desktop/Tempest/BufferValueWriter.cs
+++ b/Desktop/Tempest/BufferValueWriter.cs
@@ -100,19 +100,7 @@ namespace Tempest
 
 		public void WriteBytes (byte[] value, int offset, int length)
 		{
-			if (value == null)
-				throw new ArgumentNullException ("value");
-			if (offset < 0 || offset >= value.Length)
-				throw new ArgumentOutOfRangeException ("offset", "offset can not negative or >=data.Length");
-			if (length < 0 || offset + length > value.Length)
-				throw new ArgumentOutOfRangeException ("length", "length can not be negative or combined with offset longer than the array");
-
-			EnsureAdditionalCapacity (sizeof (int) + length);
-
-			Buff.BlockCopy (BitConverter.GetBytes (length), 0, this.buffer, this.position, sizeof (int));
-			this.position += sizeof (int);
-			Buff.BlockCopy (value, offset, this.buffer, this.position, length);
-			this.position += length;
+			InsertBytes (this.position, value, offset, length);
 		}
 
 		public void InsertBytes (int offset, byte[] value, int valueOffset, int length)

--- a/Desktop/Tempest/Providers/Network/NetworkConnection.cs
+++ b/Desktop/Tempest/Providers/Network/NetworkConnection.cs
@@ -649,6 +649,9 @@ namespace Tempest.Providers.Network
 							if (message.Header.IsResponse)
 								Responses.Receive (message);
 						}
+
+						if (message.Reusable)
+							message.Protocol.Reuse (message);
 					}
 				}
 

--- a/Desktop/Tempest/Tests/MockMessage.cs
+++ b/Desktop/Tempest/Tests/MockMessage.cs
@@ -90,7 +90,8 @@ namespace Tempest.Tests
 				new KeyValuePair<Type, Func<Message>> (typeof (BlankMessage), () => new BlankMessage()), 
 				new KeyValuePair<Type, Func<Message>> (typeof (AuthenticatedMessage), () => new AuthenticatedMessage()), 
 				new KeyValuePair<Type, Func<Message>> (typeof (EncryptedMessage), () => new EncryptedMessage()), 
-				new KeyValuePair<Type, Func<Message>> (typeof (AuthenticatedAndEncryptedMessage), () => new AuthenticatedAndEncryptedMessage()), 
+				new KeyValuePair<Type, Func<Message>> (typeof (AuthenticatedAndEncryptedMessage), () => new AuthenticatedAndEncryptedMessage()),
+				new KeyValuePair<Type, Func<Message>> (typeof (ReusedMessage), () => new ReusedMessage()), 
 			});
 		}
 	}
@@ -252,6 +253,42 @@ namespace Tempest.Tests
 
 		public override void ReadPayload (ISerializationContext context, IValueReader reader)
 		{
+		}
+	}
+
+	public class ReusedMessage
+		: Message
+	{
+		public ReusedMessage()
+			: base (MockProtocol.Instance, 6)
+		{
+		}
+
+		public byte[] Data
+		{
+			get;
+			set;
+		}
+
+		public int DataLength
+		{
+			get;
+			set;
+		}
+
+		public override void WritePayload (ISerializationContext context, IValueWriter writer)
+		{
+			writer.WriteInt32 (DataLength);
+			writer.WriteBytes (Data, 0, DataLength);
+		}
+
+		public override void ReadPayload (ISerializationContext context, IValueReader reader)
+		{
+			DataLength = reader.ReadInt32();
+			if (Reused)
+				reader.ReadBytesInto (Data, 0, DataLength);
+			else
+				Data = reader.ReadBytes (DataLength);
 		}
 	}
 }

--- a/Desktop/Tempest/Tests/ReaderWriterPairTests.cs
+++ b/Desktop/Tempest/Tests/ReaderWriterPairTests.cs
@@ -128,11 +128,32 @@ namespace Tempest.Tests
 			writer.WriteBytes (data, 2, 3);
 			writer.Flush();
 
-			data = GetReader (writer).ReadBytes();
+			data = GetReader (writer).ReadBytes (3);
 			Assert.AreEqual (3, data.Length);
 			Assert.AreEqual (0xF, data[0]);
 			Assert.AreEqual (0x10, data[1]);
 			Assert.AreEqual (0x17, data[2]);
+		}
+
+		[Test]
+		public void ReadInto()
+		{
+			IValueWriter writer = GetWriter();
+			byte[] data = new byte[] { 0x4, 0x8, 0xF, 0x10, 0x17, 0x2A };
+			writer.WriteBytes (data, 0, data.Length);
+			writer.Flush ();
+
+			IValueReader reader = GetReader (writer);
+			byte[] newData = new byte[8];
+
+			const int offset = 1;
+			reader.ReadBytesInto (newData, offset, data.Length);
+			for (int i = 0; i < newData.Length; i++) {
+				if (i >= offset && i < data.Length + offset)
+					Assert.AreEqual (data[i-offset], newData[i]);
+				else
+					Assert.AreEqual (0x0, newData[i]);
+			}
 		}
 
 		[Test]

--- a/Tempest/IValueReader.cs
+++ b/Tempest/IValueReader.cs
@@ -40,6 +40,7 @@ namespace Tempest
 		/// <summary>
 		/// Reads an array of unsigned bytes from the transport.
 		/// </summary>
+		[Obsolete ("Use ReadBytes (int) instead and read the size manually.")]
 		byte[] ReadBytes ();
 
 		/// <summary>
@@ -48,6 +49,14 @@ namespace Tempest
 		/// <param name="count">The number of bytes to read.</param>
 		/// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is &lt; 0.</exception>
 		byte[] ReadBytes (int count);
+
+		/// <summary>
+		/// Reads the next <paramref name="count"/> bytes from the transport into the <paramref name="target"/>.
+		/// </summary>
+		/// <param name="target">The array to copy into.</param>
+		/// <param name="offset">The index of <paramref name="target"/> to start from.</param>
+		/// <param name="count">The number of bytes to copy.</param>
+		void ReadBytesInto (byte[] target, int offset, int count);
 
 		/// <summary>
 		/// Reads a signed byte (SByte) from the transport.

--- a/Tempest/IValueWriter.cs
+++ b/Tempest/IValueWriter.cs
@@ -59,6 +59,7 @@ namespace Tempest
 		/// </summary>
 		/// <param name="value">The value to write.</param>
 		/// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+		[Obsolete]
 		void WriteBytes (byte[] value);
 
 		/// <summary>

--- a/Tempest/InternalProtocol/FinalConnectMessage.cs
+++ b/Tempest/InternalProtocol/FinalConnectMessage.cs
@@ -69,16 +69,24 @@ namespace Tempest.InternalProtocol
 
 		public override void WritePayload (ISerializationContext context, IValueWriter writer)
 		{
-			writer.WriteBytes (AESKey);
+			writer.WriteInt32 (AESKey.Length);
+			writer.WriteBytes (AESKey, 0, AESKey.Length);
+
 			writer.WriteString (PublicAuthenticationKeyType.GetSimplestName());
-			writer.WriteBytes (PublicAuthenticationKey);
+
+			writer.WriteInt32 (PublicAuthenticationKey.Length);
+			writer.WriteBytes (PublicAuthenticationKey, 0, PublicAuthenticationKey.Length);
 		}
 
 		public override void ReadPayload (ISerializationContext context, IValueReader reader)
 		{
-			AESKey = reader.ReadBytes();
+			int aesLen = reader.ReadInt32();
+			AESKey = reader.ReadBytes (aesLen);
+
 			PublicAuthenticationKeyType = Type.GetType (reader.ReadString());
-			PublicAuthenticationKey = reader.ReadBytes();
+
+			int pakLen = reader.ReadInt32();
+			PublicAuthenticationKey = reader.ReadBytes (pakLen);
 		}
 	}
 }

--- a/Tempest/InternalProtocol/PartialMessage.cs
+++ b/Tempest/InternalProtocol/PartialMessage.cs
@@ -76,6 +76,8 @@ namespace Tempest.InternalProtocol
 		{
 			writer.WriteUInt16 (OriginalMessageId);
 			writer.WriteByte (Count);
+
+			writer.WriteInt32 (this.length);
 			writer.WriteBytes (Payload, this.offset, this.length);
 		}
 
@@ -83,7 +85,9 @@ namespace Tempest.InternalProtocol
 		{
 			OriginalMessageId = reader.ReadUInt16();
 			Count = reader.ReadByte();
-			Payload = reader.ReadBytes();
+
+			int payloadLength = reader.ReadInt32();
+			Payload = reader.ReadBytes (payloadLength);
 		}
 
 		private int offset;

--- a/Tempest/Message.cs
+++ b/Tempest/Message.cs
@@ -109,6 +109,24 @@ namespace Tempest
 		}
 
 		/// <summary>
+		/// Gets or sets whether the message is reusable.
+		/// </summary>
+		public bool Reusable
+		{
+			get;
+			set;
+		}
+
+		/// <summary>
+		/// Gets whether the message being read into is a reused.
+		/// </summary>
+		public bool Reused
+		{
+			get;
+			internal set;
+		}
+
+		/// <summary>
 		/// Writes the message payload with <paramref name="writer"/>.
 		/// </summary>
 		/// <param name="context"></param>

--- a/Tempest/StreamValueReader.cs
+++ b/Tempest/StreamValueReader.cs
@@ -75,6 +75,22 @@ namespace Tempest
 			return buffer;
 		}
 
+		public void ReadBytesInto (byte[] target, int offset, int count)
+		{
+			if (target == null)
+				throw new ArgumentNullException (nameof (target));
+			if (offset < 0 || offset >= target.Length)
+				throw new ArgumentOutOfRangeException (nameof (offset), "offset must be in the bounds of the target");
+			if (count < 0 || offset + count > target.Length)
+				throw new ArgumentOutOfRangeException (nameof (count));
+
+			int bytes = 0;
+			while ((bytes = this.stream.Read (target, offset, count)) > 0) {
+				count -= bytes;
+				offset += bytes;
+			}
+		}
+
 		public sbyte ReadSByte()
 		{
 			return (sbyte)this.stream.ReadByte();

--- a/Tempest/StreamValueWriter.cs
+++ b/Tempest/StreamValueWriter.cs
@@ -80,10 +80,9 @@ namespace Tempest
 				throw new ArgumentNullException ("value");
 			if (offset < 0 || offset >= value.Length)
 				throw new ArgumentOutOfRangeException ("offset", "offset can not negative or >=data.Length");
-			if (length < 0 || offset + length >= value.Length)
+			if (length < 0 || offset + length > value.Length)
 				throw new ArgumentOutOfRangeException ("length", "length can not be negative or combined with offset longer than the array");
 
-			WriteInt32 (length);
 			this.stream.Write (value, offset, length);
 		}
 


### PR DESCRIPTION
This adds the ability to mark messages as reusable in the message handler.
When the handler returns, Tempest will pool the messages for reuse so
things like large byte arrays can be reused without being reallocated.

Additionally, this deprecates the simpler get/write bytes APIs. As the new
reusable ability needed a more controllable way of dealing with byte array
length, the write/read APIs weren't terrible consistent on whether they
were automatically handling the length for you or not. As a result, the
magic API has been deprecated and the one where you specify a length no
longer writes that length to the stream for you. It's trivial to write an
extension method or simply write the length yourself beforehand.

Reusing messages for sending is coming next.